### PR TITLE
Get one fbt query perf

### DIFF
--- a/src/server/migrations/20250130_00_add_feedback_target_id_index_to_summaries.js
+++ b/src/server/migrations/20250130_00_add_feedback_target_id_index_to_summaries.js
@@ -1,0 +1,11 @@
+module.exports = {
+  up: async queryInterface => {
+    await queryInterface.addIndex('summaries', {
+      fields: ['feedback_target_id'],
+      name: 'summaries_feedback_target_id',
+    })
+  },
+  down: async queryInterface => {
+    await queryInterface.removeIndex('summaries_feedback_target_id')
+  },
+}

--- a/src/server/services/feedbackTargets/getOneForUser.js
+++ b/src/server/services/feedbackTargets/getOneForUser.js
@@ -162,7 +162,7 @@ const getFromDb = async id => {
 }
 
 const getAdditionalDataFromCacheOrDb = async id => {
-  let data = null // await cache.get(id)
+  let data = await cache.get(id)
   if (!data) {
     data = await getFromDb(id)
     cache.set(data.id, data)

--- a/src/server/services/feedbackTargets/getOneForUser.js
+++ b/src/server/services/feedbackTargets/getOneForUser.js
@@ -63,6 +63,7 @@ const getFromDb = async id => {
       {
         model: UserFeedbackTarget,
         as: 'userFeedbackTargets',
+        separate: true,
         include: {
           model: User,
           as: 'user',
@@ -161,7 +162,7 @@ const getFromDb = async id => {
 }
 
 const getAdditionalDataFromCacheOrDb = async id => {
-  let data = await cache.get(id)
+  let data = null // await cache.get(id)
   if (!data) {
     data = await getFromDb(id)
     cache.set(data.id, data)


### PR DESCRIPTION
Fixes slow performance when fetching `/api/feedback-targets/:id`.

This is critical because the endpoint could sometimes be so slow it timed out and returned an error view to the user.

This was caused by changes in #1428 , there was an expensive join to `summaries` by `feedback_target_id` without an index.

In addition, joining `user_feedback_targets` in a single query was expensive.

Tested on a local machine with a fbt with around 150/200 feedbacks:

Before: 4000 ms

Adding an index: 800 ms

Separate query for ufbts: 100 ms