### PR TITLE
Improve my teaching perf

### DIFF
--- a/src/server/services/myTeaching/myTeachingService.js
+++ b/src/server/services/myTeaching/myTeachingService.js
@@ -53,17 +53,10 @@ const getAllTeacherCourseUnits = async (user, query) => {
             model: UserFeedbackTarget.scope('teachers'),
             as: 'userFeedbackTargets',
             required: true,
-            attributes: ['id'],
+            attributes: [],
             where: {
               userId: user.id,
             },
-          },
-          {
-            model: UserFeedbackTarget.scope('students'),
-            as: 'students',
-            required: false,
-            separate: true,
-            attributes: ['id'],
           },
           {
             model: Summary,

--- a/src/server/services/organisations/organisationSurveys.js
+++ b/src/server/services/organisations/organisationSurveys.js
@@ -229,11 +229,10 @@ const getSurveyById = async feedbackTargetId => {
         required: true,
       },
       {
-        model: UserFeedbackTarget,
+        model: UserFeedbackTarget.scope('students'),
         attributes: ['id'],
         as: 'students',
         required: false,
-        where: { accessStatus: 'STUDENT' },
         include: {
           model: User,
           attributes: ['studentNumber'],

--- a/src/server/test/seed.js
+++ b/src/server/test/seed.js
@@ -106,8 +106,8 @@ const seedUniversity = async () => {
 
 const seedDb = async () => {
   // Reset caches
-  userCache.invalidateAll()
-  feedbackTargetCache.invalidateAll()
+  await userCache.invalidateAll()
+  await feedbackTargetCache.invalidateAll()
 
   // First reset all tables
 


### PR DESCRIPTION
My teaching is the first page loaded for teaching personnel, so its pretty important to be fast

Recently some have noticed it to be very slow (for example #1420 )

This PR removes an unused join (students) from the main query in the endpoint. 

On a local machine this improves the response time roughly 2x (from 400 ms to 200 ms) for a teacher with a lot of courses.

Its still unclear if this fixes the slowness in production, but at least it is an improvement.
