### PR TITLE
fix: small typo in finnish translations

### DIFF
--- a/public/locales/fi/translation.json
+++ b/public/locales/fi/translation.json
@@ -355,7 +355,7 @@
   },
   "userInformation": {
     "iamGroups": "IAM-ryhmät",
-    "iamTooltip": "Näytetään vain Norppaan vaikutavat",
+    "iamTooltip": "Näytetään vain Norppaan vaikuttavat",
     "organisationAccess": "Organisaatio-oikeudet",
     "organisationCode": "Organisaatiokoodi",
     "access": "Oikeus",


### PR DESCRIPTION
Fix for a small typo I found under profile info 🤓

<img width="901" height="340" alt="image" src="https://github.com/user-attachments/assets/59ad0904-1dfa-453a-b896-02e521d5ecc6" />
